### PR TITLE
Revert withdraw changes

### DIFF
--- a/packages/token-staking/src/idl.ts
+++ b/packages/token-staking/src/idl.ts
@@ -355,12 +355,6 @@ export const _SplTokenStakingIDL = {
           docs: ["stake_mint of StakePool that will be burned"],
         },
         {
-          name: "from",
-          isMut: false,
-          isSigner: false,
-          docs: ["[dead] left in for backwards compatibility."],
-        },
-        {
           name: "destination",
           isMut: true,
           isSigner: false,

--- a/packages/token-staking/src/idl.ts
+++ b/packages/token-staking/src/idl.ts
@@ -355,6 +355,14 @@ export const _SplTokenStakingIDL = {
           docs: ["stake_mint of StakePool that will be burned"],
         },
         {
+          name: "from",
+          isMut: true,
+          isSigner: false,
+          docs: [
+            "Token Account holding weighted stake representation token to burn",
+          ],
+        },
+        {
           name: "destination",
           isMut: true,
           isSigner: false,

--- a/programs/spl-token-staking/src/instructions/withdraw.rs
+++ b/programs/spl-token-staking/src/instructions/withdraw.rs
@@ -18,10 +18,6 @@ pub struct Withdraw<'info> {
     #[account(mut)]
     pub stake_mint: Account<'info, Mint>,
 
-    /// [dead] left in for backwards compatibility.
-    /// CHECK: unused account, no check needed
-    pub from: UncheckedAccount<'info>,
-
     /// Token account to transfer the previously staked token to
     #[account(mut)]
     pub destination: Account<'info, TokenAccount>,

--- a/programs/spl-token-staking/src/instructions/withdraw.rs
+++ b/programs/spl-token-staking/src/instructions/withdraw.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::{self, Mint, TokenAccount, Transfer};
+use anchor_spl::token::{self, Burn, Mint, TokenAccount, Transfer};
 
-use crate::{errors::ErrorCode, stake_pool_signer_seeds};
+use crate::{errors::ErrorCode, stake_pool_signer_seeds, state::StakeDepositReceipt};
 
 use super::claim_base::*;
 use crate::state::u128;
@@ -17,6 +17,10 @@ pub struct Withdraw<'info> {
     /// stake_mint of StakePool that will be burned
     #[account(mut)]
     pub stake_mint: Account<'info, Mint>,
+
+    /// Token Account holding weighted stake representation token to burn
+    #[account(mut)]
+    pub from: Account<'info, TokenAccount>,
 
     /// Token account to transfer the previously staked token to
     #[account(mut)]
@@ -34,6 +38,10 @@ impl<'info> Withdraw<'info> {
         require!(
             stake_pool.stake_mint.key() == self.stake_mint.key(),
             ErrorCode::InvalidStakeMint
+        );
+        require!(
+            self.from.owner.key() == self.claim_base.owner.key(),
+            ErrorCode::InvalidAuthority
         );
         Ok(())
     }
@@ -54,6 +62,23 @@ impl<'info> Withdraw<'info> {
             cpi_ctx,
             self.claim_base.stake_deposit_receipt.deposit_amount,
         )
+    }
+
+    pub fn burn_stake_weight_tokens_from_owner(&self) -> Result<()> {
+        let stake_pool = self.claim_base.stake_pool.load()?;
+        let cpi_ctx = CpiContext::new(
+            self.claim_base.token_program.to_account_info(),
+            Burn {
+                mint: self.stake_mint.to_account_info(),
+                from: self.from.to_account_info(),
+                authority: self.claim_base.owner.to_account_info(),
+            },
+        );
+        let effective_stake_token_amount = StakeDepositReceipt::get_token_amount_from_stake(
+            self.claim_base.stake_deposit_receipt.effective_stake_u128(),
+            stake_pool.max_weight,
+        );
+        token::burn(cpi_ctx, effective_stake_token_amount)
     }
 
     pub fn close_stake_deposit_receipt(&self) -> Result<()> {
@@ -86,6 +111,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Withdraw<'info>>) -> Resul
         stake_pool.total_weighted_stake = u128(total_staked.to_le_bytes());
     }
     ctx.accounts.transfer_staked_tokens_to_owner()?;
+    ctx.accounts.burn_stake_weight_tokens_from_owner()?;
     // claim all unclaimed rewards
     let claimed_amounts = ctx
         .accounts

--- a/tests/withdraw.ts
+++ b/tests/withdraw.ts
@@ -117,7 +117,6 @@ describe("withdraw", () => {
         },
         vault: vaultKey,
         stakeMint,
-        from: anchor.web3.PublicKey.default,
         destination: mintToBeStakedAccountKey,
       })
       .remainingAccounts([
@@ -229,7 +228,6 @@ describe("withdraw", () => {
         },
         vault: vaultKey,
         stakeMint,
-        from: anchor.web3.PublicKey.default,
         destination: mintToBeStakedAccountKey,
       })
       .remainingAccounts([
@@ -310,7 +308,6 @@ describe("withdraw", () => {
           },
           vault: vaultKey,
           stakeMint,
-          from: anchor.web3.PublicKey.default,
           destination: mintToBeStakedAccountKey,
         })
         .remainingAccounts([
@@ -398,7 +395,6 @@ describe("withdraw", () => {
             },
             vault: vaultKey,
             stakeMint,
-            from: anchor.web3.PublicKey.default,
             destination: mintToBeStakedAccountKey,
           })
           .remainingAccounts([


### PR DESCRIPTION
Upon further review, removing token burn from Withdraw IX would cause the token supply to grow unbounded, which would cause DOS when supply reached u64::MAX.