### PR TITLE
Token 2022 upgrade

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -13,8 +13,8 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 # test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts -r tests/hooks.ts"
-#test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/initialize-stake-pool.ts -r tests/hooks.ts"
- test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/*.ts -r tests/token-2022/hooks22.ts"
+#test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/initialize-stake-pool.ts -r tests/hooks.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/*.ts -r tests/token-2022/hooks22.ts"
 
 [test.validator]
 [[test.genesis]]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -15,11 +15,13 @@ wallet = "~/.config/solana/id.json"
 # Classic Token program tests
 # test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/*.ts -r tests/hooks.ts"
 # test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/initialize-stake-pool.ts -r tests/hooks.ts"
+# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/claim-all.ts -r tests/hooks.ts"
 
-# Token 2022 specific tests
-# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/*.ts -r tests/token-2022/hooks22.ts"
+# Token 2022 specific tests (currently do not play nice with classic tests)
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/*.ts -r tests/token-2022/hooks22.ts"
 # test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/01*.ts -r tests/token-2022/hooks22.ts"
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/03*.ts -r tests/token-2022/hooks22.ts"
+# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/03*.ts -r tests/token-2022/hooks22.ts"
+# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/04*.ts -r tests/token-2022/hooks22.ts"
 
 [test.validator]
 [[test.genesis]]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -12,9 +12,14 @@ cluster = "Localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts -r tests/hooks.ts"
-#test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/initialize-stake-pool.ts -r tests/hooks.ts"
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/*.ts -r tests/token-2022/hooks22.ts"
+# Classic Token program tests
+# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/*.ts -r tests/hooks.ts"
+# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/initialize-stake-pool.ts -r tests/hooks.ts"
+
+# Token 2022 specific tests
+# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/*.ts -r tests/token-2022/hooks22.ts"
+# test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/01*.ts -r tests/token-2022/hooks22.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/token-2022/03*.ts -r tests/token-2022/hooks22.ts"
 
 [test.validator]
 [[test.genesis]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-staking"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/packages/token-staking/src/idl.ts
+++ b/packages/token-staking/src/idl.ts
@@ -306,11 +306,6 @@ export const _SplTokenStakingIDL = {
               isSigner: false,
             },
             {
-              name: "rewardMint",
-              isMut: false,
-              isSigner: false,
-            },
-            {
               name: "stakeDepositReceipt",
               isMut: true,
               isSigner: false,
@@ -362,11 +357,6 @@ export const _SplTokenStakingIDL = {
             {
               name: "stakePool",
               isMut: true,
-              isSigner: false,
-            },
-            {
-              name: "rewardMint",
-              isMut: false,
               isSigner: false,
             },
             {
@@ -752,9 +742,13 @@ export const _SplTokenStakingIDL = {
             type: "u64",
           },
           {
+            name: "decimals",
+            type: "u8",
+          },
+          {
             name: "padding0",
             type: {
-              array: ["u8", 8],
+              array: ["u8", 7],
             },
           },
         ],

--- a/packages/token-staking/src/idl.ts
+++ b/packages/token-staking/src/idl.ts
@@ -3,7 +3,7 @@ type Mutable<T> = {
 };
 
 export const _SplTokenStakingIDL = {
-  version: "2.0.0",
+  version: "2.0.1",
   name: "spl_token_staking",
   instructions: [
     {
@@ -210,6 +210,11 @@ export const _SplTokenStakingIDL = {
           ],
         },
         {
+          name: "mint",
+          isMut: false,
+          isSigner: false,
+        },
+        {
           name: "from",
           isMut: true,
           isSigner: false,
@@ -301,6 +306,11 @@ export const _SplTokenStakingIDL = {
               isSigner: false,
             },
             {
+              name: "rewardMint",
+              isMut: false,
+              isSigner: false,
+            },
+            {
               name: "stakeDepositReceipt",
               isMut: true,
               isSigner: false,
@@ -352,6 +362,11 @@ export const _SplTokenStakingIDL = {
             {
               name: "stakePool",
               isMut: true,
+              isSigner: false,
+            },
+            {
+              name: "rewardMint",
+              isMut: false,
               isSigner: false,
             },
             {

--- a/packages/token-staking/src/idl.ts
+++ b/packages/token-staking/src/idl.ts
@@ -391,6 +391,12 @@ export const _SplTokenStakingIDL = {
           isSigner: false,
           docs: ["Token account to transfer the previously staked token to"],
         },
+        {
+          name: "mint",
+          isMut: false,
+          isSigner: false,
+          docs: ["Staking pool's mint"],
+        },
       ],
       args: [],
     },

--- a/packages/token-staking/src/instructions.ts
+++ b/packages/token-staking/src/instructions.ts
@@ -15,6 +15,7 @@ import { SplTokenStakingV0 } from "./idl_v0";
  * @param maxDuration
  * @param authority - defaults to `program.provider.publicKey`
  * @param registar - Registrar key if this StakePool uses SPL-Governance
+ * @param tokenProgram
  */
 export const initStakePool = async (
   program: anchor.Program<SplTokenStaking | SplTokenStakingV0>,
@@ -25,6 +26,7 @@ export const initStakePool = async (
   maxDuration = new anchor.BN("18446744073709551615"),
   authority?: anchor.Address,
   registrar: anchor.web3.PublicKey | null = null,
+  tokenProgram: anchor.web3.PublicKey = SPL_TOKEN_PROGRAM_ID
 ) => {
   const _authority = authority
     ? new anchor.web3.PublicKey(authority)
@@ -50,7 +52,7 @@ export const initStakePool = async (
       stakePool: stakePoolKey,
       mint,
       vault: vaultKey,
-      tokenProgram: SPL_TOKEN_PROGRAM_ID,
+      tokenProgram: tokenProgram,
       rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       systemProgram: anchor.web3.SystemProgram.programId,
     })
@@ -65,6 +67,7 @@ export const initStakePool = async (
  * @param rewardMint
  * @param rewardPoolIndex
  * @param authority
+ * @param tokenProgram
  * @returns
  */
 export const addRewardPool = async (
@@ -73,7 +76,8 @@ export const addRewardPool = async (
   stakePoolMint: anchor.Address,
   rewardMint: anchor.web3.PublicKey,
   rewardPoolIndex = 0,
-  authority?: anchor.Address
+  authority?: anchor.Address,
+  tokenProgram: anchor.web3.PublicKey = SPL_TOKEN_PROGRAM_ID,
 ) => {
   const _authority = authority
     ? new anchor.web3.PublicKey(authority)
@@ -103,7 +107,7 @@ export const addRewardPool = async (
       rewardMint,
       stakePool: stakePoolKey,
       rewardVault: rewardVaultKey,
-      tokenProgram: SPL_TOKEN_PROGRAM_ID,
+      tokenProgram: tokenProgram,
       rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       systemProgram: anchor.web3.SystemProgram.programId,
     })
@@ -115,6 +119,7 @@ export const addRewardPool = async (
  * @param program
  * @param payer
  * @param owner
+ * @param mint
  * @param stakePoolKey
  * @param from
  * @param amount
@@ -127,6 +132,7 @@ export const createStakeBuilder = (
   program: anchor.Program<SplTokenStaking | SplTokenStakingV0>,
   payer: anchor.web3.PublicKey,
   owner: anchor.web3.PublicKey,
+  mint: anchor.web3.PublicKey,
   stakePoolKey: anchor.Address,
   from: anchor.Address,
   amount: anchor.BN,
@@ -157,6 +163,7 @@ export const createStakeBuilder = (
     .accounts({
       payer,
       owner,
+      mint: mint,
       from,
       stakePool: stakePoolKey,
       vault: vaultKey,
@@ -178,6 +185,7 @@ export const createStakeBuilder = (
  * @param program
  * @param payer
  * @param owner
+ * @param mint
  * @param stakePoolKey
  * @param from
  * @param amount
@@ -190,6 +198,7 @@ export const createStakeInstruction = async (
   program: anchor.Program<SplTokenStaking | SplTokenStakingV0>,
   payer: anchor.web3.PublicKey,
   owner: anchor.web3.PublicKey,
+  mint: anchor.web3.PublicKey,
   stakePoolkey: anchor.Address,
   from: anchor.Address,
   amount: anchor.BN,
@@ -201,6 +210,7 @@ export const createStakeInstruction = async (
     program,
     payer,
     owner,
+    mint,
     stakePoolkey,
     from,
     amount,
@@ -227,6 +237,7 @@ export const deposit = async (
   program: anchor.Program<SplTokenStaking | SplTokenStakingV0>,
   payer: anchor.web3.PublicKey,
   owner: anchor.web3.PublicKey,
+  mint: anchor.web3.PublicKey,
   stakePoolKey: anchor.Address,
   from: anchor.Address,
   amount: anchor.BN,
@@ -245,6 +256,7 @@ export const deposit = async (
     program,
     payer,
     owner,
+    mint,
     stakePoolKey,
     from,
     amount,

--- a/programs/spl-token-staking/Cargo.toml
+++ b/programs/spl-token-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-staking"
-version = "2.0.0"
+version = "2.0.1"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/programs/spl-token-staking/src/instructions/add_reward_pool.rs
+++ b/programs/spl-token-staking/src/instructions/add_reward_pool.rs
@@ -1,35 +1,35 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{
-  Mint as MintInterface, TokenAccount as TokenAccountInterface, TokenInterface,
+    Mint as MintInterface, TokenAccount as TokenAccountInterface, TokenInterface,
 };
 
-use crate::state::{RewardPool, StakePool};
 use crate::errors::ErrorCode;
+use crate::state::{RewardPool, StakePool};
 
 #[derive(Accounts)]
 #[instruction(index: u8)]
 pub struct AddRewardPool<'info> {
-  /// Payer of rent
-  #[account(mut)]
-  pub payer: Signer<'info>,
+    /// Payer of rent
+    #[account(mut)]
+    pub payer: Signer<'info>,
 
-  /// Authority of the StakePool
-  pub authority: Signer<'info>,
+    /// Authority of the StakePool
+    pub authority: Signer<'info>,
 
-  /// SPL Token Mint of the token that will be distributed as rewards
-  pub reward_mint: InterfaceAccount<'info, MintInterface>,
+    /// SPL Token Mint of the token that will be distributed as rewards
+    pub reward_mint: InterfaceAccount<'info, MintInterface>,
 
-  /// StakePool where the RewardPool will be added
-  #[account(
-    mut, 
-    has_one = authority @ ErrorCode::InvalidAuthority,
-    constraint = stake_pool.load()?.reward_pools[usize::from(index)].reward_vault == Pubkey::default() 
-      @ ErrorCode::RewardPoolIndexOccupied,
-  )]
-  pub stake_pool: AccountLoader<'info, StakePool>,
+    /// StakePool where the RewardPool will be added
+    #[account(
+      mut,
+      has_one = authority @ ErrorCode::InvalidAuthority,
+      constraint = stake_pool.load()?.reward_pools[usize::from(index)].reward_vault == Pubkey::default()
+        @ ErrorCode::RewardPoolIndexOccupied,
+    )]
+    pub stake_pool: AccountLoader<'info, StakePool>,
 
-  /// An SPL token Account for holding rewards to be claimed
-  #[account(
+    /// An SPL token Account for holding rewards to be claimed
+    #[account(
     init,
     seeds = [stake_pool.key().as_ref(), reward_mint.key().as_ref(), b"rewardVault"],
     bump,
@@ -37,17 +37,20 @@ pub struct AddRewardPool<'info> {
     token::mint = reward_mint,
     token::authority = stake_pool,
   )]
-  pub reward_vault: InterfaceAccount<'info, TokenAccountInterface>,
+    pub reward_vault: InterfaceAccount<'info, TokenAccountInterface>,
 
-  pub token_program: Interface<'info, TokenInterface>,
-  pub rent: Sysvar<'info, Rent>,
-  pub system_program: Program<'info, System>,
+    pub token_program: Interface<'info, TokenInterface>,
+    pub rent: Sysvar<'info, Rent>,
+    pub system_program: Program<'info, System>,
 }
 
 pub fn handler(ctx: Context<AddRewardPool>, index: u8) -> Result<()> {
-  let mut stake_pool = ctx.accounts.stake_pool.load_mut()?;
-  let reward_pool = RewardPool::new(&ctx.accounts.reward_vault.key());
-  stake_pool.reward_pools[usize::from(index)] = reward_pool;
+    let mut stake_pool = ctx.accounts.stake_pool.load_mut()?;
+    let reward_pool = RewardPool::new(
+        &ctx.accounts.reward_vault.key(),
+        ctx.accounts.reward_mint.decimals,
+    );
+    stake_pool.reward_pools[usize::from(index)] = reward_pool;
 
-  Ok(())
+    Ok(())
 }

--- a/programs/spl-token-staking/src/instructions/add_reward_pool.rs
+++ b/programs/spl-token-staking/src/instructions/add_reward_pool.rs
@@ -1,5 +1,7 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::{Mint, Token, TokenAccount};
+use anchor_spl::token_interface::{
+  Mint as MintInterface, TokenAccount as TokenAccountInterface, TokenInterface,
+};
 
 use crate::state::{RewardPool, StakePool};
 use crate::errors::ErrorCode;
@@ -15,7 +17,7 @@ pub struct AddRewardPool<'info> {
   pub authority: Signer<'info>,
 
   /// SPL Token Mint of the token that will be distributed as rewards
-  pub reward_mint: Account<'info, Mint>,
+  pub reward_mint: InterfaceAccount<'info, MintInterface>,
 
   /// StakePool where the RewardPool will be added
   #[account(
@@ -35,9 +37,9 @@ pub struct AddRewardPool<'info> {
     token::mint = reward_mint,
     token::authority = stake_pool,
   )]
-  pub reward_vault: Account<'info, TokenAccount>,
+  pub reward_vault: InterfaceAccount<'info, TokenAccountInterface>,
 
-  pub token_program: Program<'info, Token>,
+  pub token_program: Interface<'info, TokenInterface>,
   pub rent: Sysvar<'info, Rent>,
   pub system_program: Program<'info, System>,
 }

--- a/programs/spl-token-staking/src/instructions/claim_all.rs
+++ b/programs/spl-token-staking/src/instructions/claim_all.rs
@@ -12,9 +12,9 @@ pub fn handler<'info>(ctx: Context<'_, '_, 'info, 'info, ClaimAll<'info>>) -> Re
     {
         let mut stake_pool = ctx.accounts.claim_base.stake_pool.load_mut()?;
         let step = if ctx.accounts.claim_base.token_program.key() == Token2022::id() {
-            2usize
-        } else {
             3usize
+        } else {
+            2usize
         };
         stake_pool.recalculate_rewards_per_effective_stake(&ctx.remaining_accounts, step)?;
     }

--- a/programs/spl-token-staking/src/instructions/claim_all.rs
+++ b/programs/spl-token-staking/src/instructions/claim_all.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use anchor_spl::token_2022::Token2022;
 
 use super::claim_base::*;
 
@@ -10,7 +11,12 @@ pub struct ClaimAll<'info> {
 pub fn handler<'info>(ctx: Context<'_, '_, 'info, 'info, ClaimAll<'info>>) -> Result<()> {
     {
         let mut stake_pool = ctx.accounts.claim_base.stake_pool.load_mut()?;
-        stake_pool.recalculate_rewards_per_effective_stake(&ctx.remaining_accounts, 2usize)?;
+        let step = if ctx.accounts.claim_base.token_program.key() == Token2022::id() {
+            2usize
+        } else {
+            3usize
+        };
+        stake_pool.recalculate_rewards_per_effective_stake(&ctx.remaining_accounts, step)?;
     }
 
     let claimed_amounts = ctx

--- a/programs/spl-token-staking/src/instructions/claim_base.rs
+++ b/programs/spl-token-staking/src/instructions/claim_base.rs
@@ -91,9 +91,9 @@ impl<'info> ClaimBase<'info> {
             }
             // indexes for the relevant remaining accounts
             let step = if self.token_program.key() == Token2022::id() {
-                2
-            } else {
                 3
+            } else {
+                2
             };
             let reward_vault_account_index = remaining_accounts_index * step;
             let owner_account_index = reward_vault_account_index + 1;

--- a/programs/spl-token-staking/src/instructions/initialize_stake_pool.rs
+++ b/programs/spl-token-staking/src/instructions/initialize_stake_pool.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token};
 use anchor_spl::token_2022::Token2022;
-use anchor_spl::token_interface::{TokenAccount as TokenAccountInterface, Mint as MintInterface};
+use anchor_spl::token_interface::{Mint as MintInterface, TokenAccount as TokenAccountInterface, TokenInterface};
 
 use crate::{
     errors::ErrorCode,
@@ -31,7 +31,7 @@ pub struct InitializeStakePool<'info> {
 
     /// SPL Token Mint of the underlying token to be deposited for staking
     #[account(
-      // TODO validate token or 2022
+      // TODO validate token or token2022
     )]
     pub mint: InterfaceAccount<'info, MintInterface>,
 
@@ -51,11 +51,16 @@ pub struct InitializeStakePool<'info> {
 
     /// An SPL token Account for staging A tokens
     #[account(
-      // TODO validate token or 2022
+      init,
+      seeds = [&stake_pool.key().to_bytes()[..], b"vault"],
+      bump,
+      payer = payer,
+      token::mint = mint,
+      token::authority = stake_pool
     )]
     pub vault: InterfaceAccount<'info, TokenAccountInterface>,
 
-    pub token_program: Program<'info, Token2022>,
+    pub token_program: Interface<'info, TokenInterface>,
     pub rent: Sysvar<'info, Rent>,
     pub system_program: Program<'info, System>,
 }

--- a/programs/spl-token-staking/src/instructions/initialize_stake_pool.rs
+++ b/programs/spl-token-staking/src/instructions/initialize_stake_pool.rs
@@ -1,17 +1,12 @@
-use std::str::FromStr;
-
 use anchor_lang::prelude::*;
-use anchor_spl::token::{Mint, Token};
-use anchor_spl::token_2022::Token2022;
-use anchor_spl::token_interface::{Mint as MintInterface, TokenAccount as TokenAccountInterface, TokenInterface};
+use anchor_spl::token_interface::{
+    Mint as MintInterface, TokenAccount as TokenAccountInterface, TokenInterface,
+};
 
 use crate::{
     errors::ErrorCode,
     state::{StakePool, SCALE_FACTOR_BASE},
 };
-
-const TOKEN: Pubkey = anchor_spl::token::spl_token::ID;
-const TOKEN_2022: Pubkey = anchor_spl::token_2022::spl_token_2022::ID;
 
 #[derive(Accounts)]
 #[instruction(
@@ -30,9 +25,6 @@ pub struct InitializeStakePool<'info> {
     pub authority: UncheckedAccount<'info>,
 
     /// SPL Token Mint of the underlying token to be deposited for staking
-    #[account(
-      // TODO validate token or token2022
-    )]
     pub mint: InterfaceAccount<'info, MintInterface>,
 
     #[account(

--- a/programs/spl-token-staking/src/instructions/initialize_stake_pool.rs
+++ b/programs/spl-token-staking/src/instructions/initialize_stake_pool.rs
@@ -31,7 +31,7 @@ pub struct InitializeStakePool<'info> {
 
     /// SPL Token Mint of the underlying token to be deposited for staking
     #[account(
-      owner = TOKEN_2022
+      // TODO validate token or 2022
     )]
     pub mint: InterfaceAccount<'info, MintInterface>,
 
@@ -51,13 +51,7 @@ pub struct InitializeStakePool<'info> {
 
     /// An SPL token Account for staging A tokens
     #[account(
-      init,
-      seeds = [&stake_pool.key().to_bytes()[..], b"vault"],
-      bump,
-      payer = payer,
-      token::mint = mint,
-      token::authority = stake_pool,
-      owner = TOKEN_2022
+      // TODO validate token or 2022
     )]
     pub vault: InterfaceAccount<'info, TokenAccountInterface>,
 

--- a/programs/spl-token-staking/src/instructions/withdraw.rs
+++ b/programs/spl-token-staking/src/instructions/withdraw.rs
@@ -1,5 +1,7 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::{self, TokenAccount, Transfer};
+use anchor_spl::token::{self, Transfer};
+use anchor_spl::token_2022::{self, Token2022, TransferChecked};
+use anchor_spl::token_interface::{Mint as MintInterface, TokenAccount as TokenAccountInterface};
 
 use crate::{
     errors::ErrorCode,
@@ -16,7 +18,7 @@ pub struct Withdraw<'info> {
 
     /// Vault of the StakePool token will be transferred from
     #[account(mut)]
-    pub vault: Account<'info, TokenAccount>,
+    pub vault: InterfaceAccount<'info, TokenAccountInterface>,
 
     #[account(
         mut,
@@ -34,7 +36,11 @@ pub struct Withdraw<'info> {
 
     /// Token account to transfer the previously staked token to
     #[account(mut)]
-    pub destination: Account<'info, TokenAccount>,
+    pub destination: InterfaceAccount<'info, TokenAccountInterface>,
+
+    // TODO could put a has_one on this but it would fail on transfer anyways if bad.
+    /// Staking pool's mint
+    pub mint: InterfaceAccount<'info, MintInterface>,
 }
 
 impl<'info> Withdraw<'info> {
@@ -51,19 +57,37 @@ impl<'info> Withdraw<'info> {
     pub fn transfer_staked_tokens_to_owner(&self) -> Result<()> {
         let stake_pool = self.claim_base.stake_pool.load()?;
         let signer_seeds: &[&[&[u8]]] = &[stake_pool_signer_seeds!(stake_pool)];
-        let cpi_ctx = CpiContext::new_with_signer(
-            self.claim_base.token_program.to_account_info(),
-            Transfer {
-                from: self.vault.to_account_info(),
-                to: self.destination.to_account_info(),
-                authority: self.claim_base.stake_pool.to_account_info(),
-            },
-            signer_seeds,
-        );
-        token::transfer(
-            cpi_ctx,
-            self.claim_base.stake_deposit_receipt.deposit_amount,
-        )
+        if self.mint.to_account_info().owner.eq(&Token2022::id()) {
+            let cpi_ctx = CpiContext::new_with_signer(
+                self.claim_base.token_program.to_account_info(),
+                TransferChecked {
+                    from: self.vault.to_account_info(),
+                    to: self.destination.to_account_info(),
+                    mint: self.mint.to_account_info(),
+                    authority: self.claim_base.stake_pool.to_account_info(),
+                },
+                signer_seeds,
+            );
+            token_2022::transfer_checked(
+                cpi_ctx,
+                self.claim_base.stake_deposit_receipt.deposit_amount,
+                self.mint.decimals,
+            )
+        } else {
+            let cpi_ctx = CpiContext::new_with_signer(
+                self.claim_base.token_program.to_account_info(),
+                Transfer {
+                    from: self.vault.to_account_info(),
+                    to: self.destination.to_account_info(),
+                    authority: self.claim_base.stake_pool.to_account_info(),
+                },
+                signer_seeds,
+            );
+            token::transfer(
+                cpi_ctx,
+                self.claim_base.stake_deposit_receipt.deposit_amount,
+            )
+        }
     }
 
     pub fn close_stake_deposit_receipt(&self) -> Result<()> {
@@ -82,7 +106,12 @@ pub fn handler<'info>(ctx: Context<'_, '_, 'info, 'info, Withdraw<'info>>) -> Re
     {
         let mut stake_pool = ctx.accounts.claim_base.stake_pool.load_mut()?;
         // Recalculate rewards for stake prior, so withdrawing user can receive all rewards
-        stake_pool.recalculate_rewards_per_effective_stake(&ctx.remaining_accounts, 2usize)?;
+        let step = if ctx.accounts.claim_base.token_program.key() == Token2022::id() {
+            3usize
+        } else {
+            2usize
+        };
+        stake_pool.recalculate_rewards_per_effective_stake(&ctx.remaining_accounts, step)?;
         // Decrement total weighted stake for future deposit reward ownership to be calculated correctly
         let total_staked = stake_pool
             .total_weighted_stake_u128()

--- a/programs/spl-token-staking/src/lib.rs
+++ b/programs/spl-token-staking/src/lib.rs
@@ -11,6 +11,12 @@ use crate::instructions::*;
 
 declare_id!("STAKEGztX7S1MUHxcQHieZhELCntb9Ys9BgUbeEtMu1");
 
+// Either token program can be used for any instruction, e.g.:
+// However, it must match the mint (e.g. if mints use 2022, you must pass 2022)
+// const TOKEN: Pubkey = anchor_spl::token::spl_token::ID;
+// const TOKEN_2022: Pubkey = anchor_spl::token_2022::spl_token_2022::ID;
+// Equivalent to {TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID} from @solana/spl-token
+
 #[program]
 pub mod spl_token_staking {
     use super::*;

--- a/programs/spl-token-staking/src/state.rs
+++ b/programs/spl-token-staking/src/state.rs
@@ -1,8 +1,5 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::TokenAccount;
-use anchor_spl::token_interface::{
-    Mint as MintInterface, TokenAccount as TokenAccountInterface, TokenInterface,
-};
+use anchor_spl::token_interface::TokenAccount as TokenAccountInterface;
 use bytemuck::{Pod, Zeroable};
 use core::primitive;
 use jet_proc_macros::assert_size;
@@ -72,7 +69,8 @@ pub struct RewardPool {
     pub rewards_per_effective_stake: u128,
     /** latest amount of tokens in the vault */
     pub last_amount: u64,
-    _padding0: [u8; 8],
+    pub decimals: u8,
+    _padding0: [u8; 7],
 }
 
 impl RewardPool {
@@ -80,9 +78,10 @@ impl RewardPool {
         self.reward_vault == Pubkey::default()
     }
 
-    pub fn new(reward_vault: &Pubkey) -> Self {
+    pub fn new(reward_vault: &Pubkey, decimals: u8) -> Self {
         let mut res = Self::default();
         res.reward_vault = *reward_vault;
+        res.decimals = decimals;
         res
     }
 

--- a/programs/spl-token-staking/src/state.rs
+++ b/programs/spl-token-staking/src/state.rs
@@ -1,5 +1,8 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::TokenAccount;
+use anchor_spl::token_interface::{
+    Mint as MintInterface, TokenAccount as TokenAccountInterface, TokenInterface,
+};
 use bytemuck::{Pod, Zeroable};
 use core::primitive;
 use jet_proc_macros::assert_size;
@@ -194,9 +197,9 @@ impl StakePool {
                 );
                 return err!(ErrorCode::InvalidRewardPoolVault);
             }
-
-            let token_account: Account<'info, TokenAccount> =
-                Account::try_from(&account_info).map_err(|_| ErrorCode::InvalidRewardPoolVault)?;
+            let token_account: InterfaceAccount<'info, TokenAccountInterface> =
+                InterfaceAccount::try_from(&account_info)
+                    .map_err(|_| ErrorCode::InvalidRewardPoolVault)?;
             remaining_accounts_index += reward_vault_account_offset;
 
             if reward_pool.last_amount == token_account.amount {

--- a/programs/spl-token-staking/src/state.rs
+++ b/programs/spl-token-staking/src/state.rs
@@ -179,8 +179,9 @@ impl StakePool {
 
             if remaining_accounts_index >= remaining_accounts.len() {
                 msg!(
-                    "Missing at least one reward vault account. Failed at index {:?}",
-                    remaining_accounts_index
+                    "Missing at least one reward vault account. Failed at index {:?} but passed {:?} accounts",
+                    remaining_accounts_index,
+                    remaining_accounts.len()
                 );
                 return err!(ErrorCode::InvalidRewardPoolVaultIndex);
             }
@@ -190,9 +191,10 @@ impl StakePool {
             // indexes line up.
             if reward_pool.reward_vault != account_info.key() {
                 msg!(
-                    "expected pool: {:?} but got {:?}",
+                    "expected pool: {:?} but got {:?} at index {:?}",
                     reward_pool.reward_vault,
-                    account_info.key()
+                    account_info.key(),
+                    remaining_accounts_index
                 );
                 return err!(ErrorCode::InvalidRewardPoolVault);
             }

--- a/tests/claim-all.ts
+++ b/tests/claim-all.ts
@@ -480,16 +480,16 @@ describe("claim-all", () => {
 
     // NOTE: we must pass an array of RewardPoolVault and user token accounts
     // as remaining accounts
-    await program.methods
+    let claimIx = await program.methods
       .claimAll()
       .accounts({
         claimBase: {
           owner: depositor1.publicKey,
           stakePool: stakePoolKey,
           stakeDepositReceipt: stakeReceiptKey,
+          tokenProgram: TOKEN_PROGRAM_ID
         },
       })
-      .signers([depositor1])
       .remainingAccounts([
         // reward 1
         {
@@ -514,7 +514,14 @@ describe("claim-all", () => {
           isSigner: false,
         },
       ])
-      .rpc({ skipPreflight: true });
+      .instruction();
+    try {
+      await program.provider.sendAndConfirm(new Transaction().add(claimIx), [
+        depositor1,
+      ]);
+    } catch (err) {
+      console.log(err);
+    }
 
     const [depositerReward1Account, depositerReward2Account] =
       await Promise.all([

--- a/tests/decimal-overflow.ts
+++ b/tests/decimal-overflow.ts
@@ -130,6 +130,7 @@ describe("decimal-overflow", () => {
       .accounts({
         payer: depositor.publicKey,
         owner: depositor.publicKey,
+        mint: mintToBeStaked,
         from: mintToBeStakedAccount,
         stakePool: stakePoolKey,
         vault: vaultKey,

--- a/tests/deposit.ts
+++ b/tests/deposit.ts
@@ -187,6 +187,7 @@ describe("deposit", () => {
       .accounts({
         payer: depositor.publicKey,
         owner: depositor.publicKey,
+        mint: mintToBeStaked,
         from: mintToBeStakedAccount,
         stakePool: stakePoolKey,
         vault: vaultKey,
@@ -279,6 +280,7 @@ describe("deposit", () => {
       .accounts({
         payer: depositor.publicKey,
         owner: depositor.publicKey,
+        mint: mintToBeStaked,
         from: mintToBeStakedAccount,
         stakePool: stakePoolKey,
         vault: vaultKey,
@@ -370,6 +372,7 @@ describe("deposit", () => {
       .accounts({
         payer: depositor.publicKey,
         owner: depositor.publicKey,
+        mint: mintToBeStaked,
         from: mintToBeStakedAccount,
         stakePool: stakePoolKey,
         vault: vaultKey,
@@ -414,6 +417,7 @@ describe("deposit", () => {
       .accounts({
         payer: depositor.publicKey,
         owner: depositor.publicKey,
+        mint: mintToBeStaked,
         from: mintToBeStakedAccount,
         stakePool: stakePoolKey,
         vault: vaultKey,
@@ -501,6 +505,7 @@ describe("deposit", () => {
         .accounts({
           payer: depositor.publicKey,
           owner: depositor.publicKey,
+          mint: mintToBeStaked,
           from: mintToBeStakedAccount,
           stakePool: stakePoolKey,
           vault: vaultKey,
@@ -552,6 +557,7 @@ describe("deposit", () => {
         .accounts({
           payer: depositor.publicKey,
           owner: depositor.publicKey,
+          mint: mintToBeStaked,
           from: mintToBeStakedAccount,
           stakePool: stakePoolKey,
           vault: vaultKey,
@@ -611,6 +617,7 @@ describe("deposit", () => {
       .accounts({
         payer: depositor.publicKey,
         owner: depositor.publicKey,
+        mint: mintToBeStaked,
         from: mintToBeStakedAccount,
         stakePool: stakePoolKey,
         vault: vaultKey,
@@ -701,6 +708,7 @@ describe("deposit", () => {
       .accounts({
         payer: depositor.publicKey,
         owner: owner.publicKey,
+        mint: mintToBeStaked,
         from: mintToBeStakedAccount,
         stakePool: stakePoolKey,
         vault: vaultKey,

--- a/tests/initialize-stake-pool.ts
+++ b/tests/initialize-stake-pool.ts
@@ -103,7 +103,6 @@ describe("initialize-stake-pool", () => {
         mint: mintToBeStaked,
         vault: vaultKey,
         tokenProgram: TOKEN_PROGRAM_ID,
-        token2022Program: TOKEN_2022_PROGRAM_ID,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
         systemProgram: anchor.web3.SystemProgram.programId,
       })

--- a/tests/token-2022/00_initialize-stake-pool.ts
+++ b/tests/token-2022/00_initialize-stake-pool.ts
@@ -1,28 +1,15 @@
 import * as anchor from "@coral-xyz/anchor";
-import { SPL_TOKEN_PROGRAM_ID, splTokenProgram } from "@coral-xyz/spl-token";
+import { splTokenProgram } from "@coral-xyz/spl-token";
 import { SplTokenStaking } from "../../target/types/spl_token_staking";
 import { assert } from "chai";
 import { mintToBeStaked } from "./hooks22";
-import {
-  SCALE_FACTOR_BASE,
-  createRegistrar,
-} from "@mithraic-labs/token-staking";
-import {
-  AccountLayout,
-  TOKEN_2022_PROGRAM_ID,
-  TOKEN_PROGRAM_ID,
-  createAssociatedTokenAccount,
-  createAssociatedTokenAccountInstruction,
-  createInitializeAccountInstruction,
-  getAssociatedTokenAddressSync,
-  getMint,
-} from "@solana/spl-token";
+import { SCALE_FACTOR_BASE } from "@mithraic-labs/token-staking";
+import { TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
 import {
   assertBNEqual,
   assertKeyDefault,
   assertKeysEqual,
 } from "../genericTests";
-import { createRealm } from "../utils";
 import {
   GOVERNANCE_PROGRAM_ID,
   GOVERNANCE_PROGRAM_SEED,
@@ -59,7 +46,7 @@ describe("initialize-stake-pool", () => {
   );
 
   before(async () => {
-    // TODO currently governance is incompatible...
+    // TODO currently governance is incompatible with Token 2022...
     // console.log("realm");
     // // create realm and registrar
     // const realmAuthority = program.provider.publicKey;
@@ -121,16 +108,12 @@ describe("initialize-stake-pool", () => {
         systemProgram: anchor.web3.SystemProgram.programId,
       })
       .instruction();
-    try {
-      await program.provider.sendAndConfirm(
-        new anchor.web3.Transaction().add(
-         // initTokenAccIx,
-          initIx
-        )
-      );
-    } catch (err) {
-      console.log(err);
-    }
+    await program.provider.sendAndConfirm(
+      new anchor.web3.Transaction().add(
+        initIx
+      )
+    );
+
     const [vault, stakePool] = await Promise.all([
       tokenProgramInstance.account.account.fetch(vaultKey),
       program.account.stakePool.fetch(stakePoolKey),

--- a/tests/token-2022/01_deposit.ts
+++ b/tests/token-2022/01_deposit.ts
@@ -1,0 +1,256 @@
+import * as anchor from "@coral-xyz/anchor";
+import { splTokenProgram } from "@coral-xyz/spl-token";
+import { assert } from "chai";
+import {
+  rewardMint1,
+  mintToBeStaked,
+  createDepositorSplAccounts,
+  TEST_MINT_DECIMALS,
+} from "./hooks22";
+import {
+  getAssociatedTokenAddressSync,
+  createTransferInstruction,
+  createAssociatedTokenAccountInstruction,
+  TOKEN_2022_PROGRAM_ID,
+  getAccount,
+} from "@solana/spl-token";
+import {
+  SCALE_FACTOR_BASE,
+  SCALE_FACTOR_BASE_BN,
+  addRewardPool,
+  calculateStakeWeight,
+  createRegistrar,
+  fetchVoterWeightRecord,
+  getDigitShift,
+  getNextUnusedStakeReceiptNonce,
+  initStakePool,
+} from "@mithraic-labs/token-staking";
+import { assertBNEqual, assertKeysEqual } from "../genericTests";
+import {
+  GOVERNANCE_PROGRAM_ID,
+  GOVERNANCE_PROGRAM_SEED,
+  createSplGovernanceProgram,
+} from "@mithraic-labs/spl-governance";
+import { createRealm } from "../utils";
+import { SplTokenStaking } from "../../target/types/spl_token_staking";
+
+const scaleFactorBN = new anchor.BN(SCALE_FACTOR_BASE.toString());
+
+describe("deposit", () => {
+  const program = anchor.workspace
+    .SplTokenStaking as anchor.Program<SplTokenStaking>;
+  // const splGovernance = createSplGovernanceProgram(
+  //   // @ts-ignore
+  //   program._provider.wallet,
+  //   program.provider.connection,
+  //   GOVERNANCE_PROGRAM_ID
+  // );
+  const tokenProgram = TOKEN_2022_PROGRAM_ID;
+  const splTokenProgramInstance = splTokenProgram({ programId: tokenProgram });
+  const depositor = new anchor.web3.Keypair();
+
+  const stakePoolNonce = 7; // TODO unique global nonce generation?
+  const [stakePoolKey] = anchor.web3.PublicKey.findProgramAddressSync(
+    [
+      new anchor.BN(stakePoolNonce).toArrayLike(Buffer, "le", 1),
+      mintToBeStaked.toBuffer(),
+      program.provider.publicKey.toBuffer(),
+      Buffer.from("stakePool", "utf-8"),
+    ],
+    program.programId
+  );
+  const [vaultKey] = anchor.web3.PublicKey.findProgramAddressSync(
+    [stakePoolKey.toBuffer(), Buffer.from("vault", "utf-8")],
+    program.programId
+  );
+  const [rewardVaultKey] = anchor.web3.PublicKey.findProgramAddressSync(
+    [
+      stakePoolKey.toBuffer(),
+      rewardMint1.toBuffer(),
+      Buffer.from("rewardVault", "utf-8"),
+    ],
+    program.programId
+  );
+  const mintToBeStakedAccount = getAssociatedTokenAddressSync(
+    mintToBeStaked,
+    depositor.publicKey,
+    false,
+    tokenProgram
+  );
+  const deposit1Amount = new anchor.BN(5_000_000_000);
+  const deposit2Amount = new anchor.BN(1_000_000_000);
+  const maxWeight = new anchor.BN(4 * parseInt(SCALE_FACTOR_BASE.toString()));
+  const minDuration = new anchor.BN(1000);
+  const maxDuration = new anchor.BN(4 * 31536000);
+  const digitShift = getDigitShift(
+    BigInt(maxWeight.toString()),
+    TEST_MINT_DECIMALS
+  );
+  const [voterWeightRecordKey] = anchor.web3.PublicKey.findProgramAddressSync(
+    [
+      stakePoolKey.toBuffer(),
+      depositor.publicKey.toBuffer(),
+      Buffer.from("voterWeightRecord", "utf-8"),
+    ],
+    program.programId
+  );
+  // const realmName = "deposit-realm";
+  // const [realmAddress] = anchor.web3.PublicKey.findProgramAddressSync(
+  //   [
+  //     Buffer.from(GOVERNANCE_PROGRAM_SEED, "utf-8"),
+  //     Buffer.from(realmName, "utf-8"),
+  //   ],
+  //   splGovernance.programId
+  // );
+  // const communityTokenMint = mintToBeStaked;
+  const [registrarKey] = [anchor.web3.PublicKey.default];
+  // anchor.web3.PublicKey.findProgramAddressSync(
+  //   [
+  //     realmAddress.toBuffer(),
+  //     communityTokenMint.toBuffer(),
+  //     Buffer.from("registrar", "utf-8"),
+  //   ],
+  //   program.programId
+  // );
+  // const realmAuthority = splGovernance.provider.publicKey;
+
+  before(async () => {
+    // TODO currently governance is incompatible with Token 2022...
+    // await createRealm(
+    //   // @ts-ignore
+    //   splGovernance,
+    //   realmName,
+    //   communityTokenMint,
+    //   realmAuthority,
+    //   program.programId
+    // );
+    // await createRegistrar(
+    //   program,
+    //   realmAddress,
+    //   mintToBeStaked,
+    //   GOVERNANCE_PROGRAM_ID,
+    //   program.provider.publicKey
+    // );
+
+    // set up depositor account and stake pool account
+
+    await createDepositorSplAccounts(program, depositor, stakePoolNonce),
+    await initStakePool(
+      program,
+      mintToBeStaked,
+      stakePoolNonce,
+      maxWeight,
+      minDuration,
+      maxDuration,
+      undefined,
+      registrarKey,
+      tokenProgram
+    );
+    await addRewardPool(
+      program,
+      stakePoolNonce,
+      mintToBeStaked,
+      rewardMint1,
+      undefined,
+      undefined,
+      tokenProgram
+    );
+    await program.methods
+      .createVoterWeightRecord()
+      .accounts({
+        owner: depositor.publicKey,
+        registrar: null, // TODO update when governance re-added.
+        stakePool: stakePoolKey,
+        voterWeightRecord: voterWeightRecordKey,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      })
+      .rpc();
+  });
+
+  it("First Deposit (5) successful", async () => {
+    const nextNonce = await getNextUnusedStakeReceiptNonce(
+      program.provider.connection,
+      program.programId,
+      depositor.publicKey,
+      stakePoolKey
+    );
+    assert.equal(nextNonce, 0);
+    const [stakeReceiptKey] = anchor.web3.PublicKey.findProgramAddressSync(
+      [
+        depositor.publicKey.toBuffer(),
+        stakePoolKey.toBuffer(),
+        new anchor.BN(nextNonce).toArrayLike(Buffer, "le", 4),
+        Buffer.from("stakeDepositReceipt", "utf-8"),
+      ],
+      program.programId
+    );
+    const [mintToBeStakedAccountBefore, voterWeightRecordBefore] =
+      await Promise.all([
+        splTokenProgramInstance.account.account.fetch(mintToBeStakedAccount),
+        fetchVoterWeightRecord(program, voterWeightRecordKey),
+      ]);
+
+    await program.methods
+      .deposit(nextNonce, deposit1Amount, minDuration)
+      .accounts({
+        payer: depositor.publicKey,
+        owner: depositor.publicKey,
+        mint: mintToBeStaked,
+        from: mintToBeStakedAccount,
+        stakePool: stakePoolKey,
+        vault: vaultKey,
+        voterWeightRecord: voterWeightRecordKey,
+        stakeDepositReceipt: stakeReceiptKey,
+        tokenProgram: tokenProgram,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      })
+      .signers([depositor])
+      .rpc({ skipPreflight: true });
+    const [
+      mintToBeStakedAccountAfter,
+      vault,
+      stakeReceipt,
+      stakePool,
+      voterWeightRecord,
+    ] = await Promise.all([
+      splTokenProgramInstance.account.account.fetch(mintToBeStakedAccount),
+      splTokenProgramInstance.account.account.fetch(vaultKey),
+      program.account.stakeDepositReceipt.fetch(stakeReceiptKey),
+      program.account.stakePool.fetch(stakePoolKey),
+      fetchVoterWeightRecord(program, voterWeightRecordKey),
+    ]);
+    const weightedStakeAmount = deposit1Amount.div(
+      new anchor.BN(10 ** digitShift)
+    );
+    assertBNEqual(
+      voterWeightRecord.voterWeight.sub(voterWeightRecordBefore.voterWeight),
+      weightedStakeAmount
+    );
+    assertBNEqual(
+      mintToBeStakedAccountBefore.amount.sub(deposit1Amount),
+      mintToBeStakedAccountAfter.amount
+    );
+    assertBNEqual(vault.amount, deposit1Amount);
+    assertKeysEqual(stakeReceipt.stakePool, stakePoolKey);
+    assertKeysEqual(stakeReceipt.owner, depositor.publicKey);
+    assertKeysEqual(stakeReceipt.payer, depositor.publicKey);
+    assertBNEqual(stakeReceipt.depositAmount, deposit1Amount);
+    stakeReceipt.claimedAmounts.forEach((claimed, index) => {
+      assert.equal(claimed.toString(), "0", `claimed index ${index} failed`);
+    });
+    assertBNEqual(stakeReceipt.lockupDuration, minDuration);
+    // May be off by 1-2 seconds
+    let now = Date.now() / 1000;
+    assert.approximately(stakeReceipt.depositTimestamp.toNumber(), now, 2);
+    assertBNEqual(
+      stakeReceipt.effectiveStake,
+      deposit1Amount.mul(scaleFactorBN)
+    );
+    assertBNEqual(
+      stakePool.totalWeightedStake,
+      deposit1Amount.mul(scaleFactorBN)
+    );
+  });
+});

--- a/tests/token-2022/03_claim-all.ts
+++ b/tests/token-2022/03_claim-all.ts
@@ -195,7 +195,6 @@ describe("claim-all", () => {
         claimBase: {
           owner: depositor1.publicKey,
           stakePool: stakePoolKey,
-          rewardMint: rewardMint1,
           stakeDepositReceipt: stakeReceiptKey,
           tokenProgram: tokenProgram,
         },
@@ -209,6 +208,11 @@ describe("claim-all", () => {
         {
           pubkey: depositerReward1AccKey,
           isWritable: true,
+          isSigner: false,
+        },
+        {
+          pubkey: rewardMint1,
+          isWritable: false,
           isSigner: false,
         },
       ])

--- a/tests/token-2022/03_claim-all.ts
+++ b/tests/token-2022/03_claim-all.ts
@@ -1,0 +1,240 @@
+import * as anchor from "@coral-xyz/anchor";
+import { splTokenProgram } from "@coral-xyz/spl-token";
+import {
+  createDepositorSplAccounts,
+  mintToBeStaked,
+  rewardMint1,
+  rewardMint2,
+} from "./hooks22";
+import {
+  TOKEN_2022_PROGRAM_ID,
+  createAssociatedTokenAccountInstruction,
+  createBurnInstruction,
+  createMintToInstruction,
+  createTransferInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
+import { assert } from "chai";
+import {
+  addRewardPool,
+  initStakePool,
+  SplTokenStaking,
+} from "@mithraic-labs/token-staking";
+import { deposit } from ".././utils";
+import { assertBNEqual } from ".././genericTests";
+import { Transaction } from "@solana/web3.js";
+
+describe("claim-all", () => {
+  const program = anchor.workspace
+    .SplTokenStaking as anchor.Program<SplTokenStaking>;
+  const tokenProgram = TOKEN_2022_PROGRAM_ID;
+  const splTokenProgramInstance = splTokenProgram({
+    programId: TOKEN_2022_PROGRAM_ID,
+  });
+  const depositor1 = new anchor.web3.Keypair();
+  const depositor2 = new anchor.web3.Keypair();
+  const stakePoolNonce = 4;
+  const [stakePoolKey] = anchor.web3.PublicKey.findProgramAddressSync(
+    [
+      new anchor.BN(stakePoolNonce).toArrayLike(Buffer, "le", 1),
+      mintToBeStaked.toBuffer(),
+      program.provider.publicKey.toBuffer(),
+      Buffer.from("stakePool", "utf-8"),
+    ],
+    program.programId
+  );
+  const [rewardVaultKey] = anchor.web3.PublicKey.findProgramAddressSync(
+    [
+      stakePoolKey.toBuffer(),
+      rewardMint1.toBuffer(),
+      Buffer.from("rewardVault", "utf-8"),
+    ],
+    program.programId
+  );
+  const mintToBeStakedAccountKey = getAssociatedTokenAddressSync(
+    mintToBeStaked,
+    depositor1.publicKey,
+    undefined,
+    tokenProgram
+  );
+  const depositerReward1AccKey = getAssociatedTokenAddressSync(
+    rewardMint1,
+    depositor1.publicKey,
+    undefined,
+    tokenProgram
+  );
+  const [voterWeightRecordKey1] = anchor.web3.PublicKey.findProgramAddressSync(
+    [
+      stakePoolKey.toBuffer(),
+      depositor1.publicKey.toBuffer(),
+      Buffer.from("voterWeightRecord", "utf-8"),
+    ],
+    program.programId
+  );
+  const [voterWeightRecordKey2] = anchor.web3.PublicKey.findProgramAddressSync(
+    [
+      stakePoolKey.toBuffer(),
+      depositor2.publicKey.toBuffer(),
+      Buffer.from("voterWeightRecord", "utf-8"),
+    ],
+    program.programId
+  );
+
+  before(async () => {
+    // set up depositor account and stake pool account
+    await Promise.all([
+      createDepositorSplAccounts(program, depositor1, stakePoolNonce),
+      createDepositorSplAccounts(program, depositor2, stakePoolNonce),
+      initStakePool(
+        program,
+        mintToBeStaked,
+        stakePoolNonce,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        tokenProgram
+      ),
+    ]);
+    // add reward pool to the initialized stake pool
+    await Promise.all([
+      addRewardPool(
+        program,
+        stakePoolNonce,
+        mintToBeStaked,
+        rewardMint1,
+        undefined,
+        undefined,
+        tokenProgram
+      ),
+      program.methods
+        .createVoterWeightRecord()
+        .accounts({
+          owner: depositor1.publicKey,
+          registrar: null,
+          stakePool: stakePoolKey,
+          voterWeightRecord: voterWeightRecordKey1,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        })
+        .rpc(),
+      program.methods
+        .createVoterWeightRecord()
+        .accounts({
+          owner: depositor2.publicKey,
+          registrar: null,
+          stakePool: stakePoolKey,
+          voterWeightRecord: voterWeightRecordKey2,
+          rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        })
+        .rpc(),
+    ]);
+  });
+
+  it("Claim all owed rewards", async () => {
+    const receiptNonce = 0;
+    const [stakeReceiptKey] = anchor.web3.PublicKey.findProgramAddressSync(
+      [
+        depositor1.publicKey.toBuffer(),
+        stakePoolKey.toBuffer(),
+        new anchor.BN(receiptNonce).toArrayLike(Buffer, "le", 4),
+        Buffer.from("stakeDepositReceipt", "utf-8"),
+      ],
+      program.programId
+    );
+    // deposit 1 token
+    await deposit(
+      program,
+      stakePoolNonce,
+      mintToBeStaked,
+      depositor1,
+      mintToBeStakedAccountKey,
+      new anchor.BN(1_000_000_000),
+      new anchor.BN(0),
+      receiptNonce,
+      voterWeightRecordKey1,
+      undefined,
+      tokenProgram
+    );
+    const totalReward1 = 1_000_000_000;
+    const transferIx = createTransferInstruction(
+      getAssociatedTokenAddressSync(
+        rewardMint1,
+        program.provider.publicKey,
+        undefined,
+        tokenProgram
+      ),
+      rewardVaultKey,
+      program.provider.publicKey,
+      totalReward1,
+      [],
+      tokenProgram
+    );
+    const createDepositorReward1AccountIx =
+      createAssociatedTokenAccountInstruction(
+        program.provider.publicKey,
+        depositerReward1AccKey,
+        depositor1.publicKey,
+        rewardMint1,
+        tokenProgram
+      );
+    // transfer 1 reward token to RewardPool at index 0
+    await program.provider.sendAndConfirm(
+      new anchor.web3.Transaction()
+        .add(transferIx)
+        .add(createDepositorReward1AccountIx)
+    );
+
+    // NOTE: we must pass an array of RewardPoolVault and user token accounts
+    // as remaining accounts
+    let ix = await program.methods
+      .claimAll()
+      .accounts({
+        claimBase: {
+          owner: depositor1.publicKey,
+          stakePool: stakePoolKey,
+          rewardMint: rewardMint1,
+          stakeDepositReceipt: stakeReceiptKey,
+          tokenProgram: tokenProgram,
+        },
+      })
+      .remainingAccounts([
+        {
+          pubkey: rewardVaultKey,
+          isWritable: true,
+          isSigner: false,
+        },
+        {
+          pubkey: depositerReward1AccKey,
+          isWritable: true,
+          isSigner: false,
+        },
+      ])
+      .instruction();
+
+      try{
+    await program.provider.sendAndConfirm(new Transaction().add(ix), [
+      depositor1,
+    ]);
+  }catch(err){
+    console.log(err);
+  }
+
+    const [depositerReward1Account, stakeReceipt, stakePool] =
+      await Promise.all([
+        splTokenProgramInstance.account.account.fetch(depositerReward1AccKey),
+        program.account.stakeDepositReceipt.fetch(stakeReceiptKey),
+        program.account.stakePool.fetch(stakePoolKey),
+      ]);
+
+    assertBNEqual(depositerReward1Account.amount, totalReward1);
+    assertBNEqual(stakeReceipt.claimedAmounts[0], totalReward1);
+    assertBNEqual(stakePool.rewardPools[0].lastAmount, 0);
+    assertBNEqual(
+      stakePool.rewardPools[0].rewardsPerEffectiveStake,
+      totalReward1 // scale weight =1
+    );
+  });
+});

--- a/tests/withdraw.ts
+++ b/tests/withdraw.ts
@@ -135,6 +135,7 @@ describe("withdraw", () => {
         vault: vaultKey,
         voterWeightRecord: voterWeightRecordKey,
         destination: mintToBeStakedAccountKey,
+        mint: mintToBeStaked,
       })
       .remainingAccounts([
         {
@@ -251,6 +252,7 @@ describe("withdraw", () => {
         vault: vaultKey,
         voterWeightRecord: voterWeightRecordKey,
         destination: mintToBeStakedAccountKey,
+        mint: mintToBeStaked,
       })
       .remainingAccounts([
         {
@@ -334,6 +336,7 @@ describe("withdraw", () => {
           vault: vaultKey,
           voterWeightRecord: voterWeightRecordKey,
           destination: mintToBeStakedAccountKey,
+          mint: mintToBeStaked,
         })
         .remainingAccounts([
           {

--- a/tests/zero-duration-pool.ts
+++ b/tests/zero-duration-pool.ts
@@ -100,6 +100,7 @@ describe("zero-duration-pool", () => {
       .accounts({
         payer: depositor.publicKey,
         owner: depositor.publicKey,
+        mint: mintToBeStaked,
         from: mintToBeStakedAccount,
         stakePool: stakePoolKey,
         vault: vaultKey,


### PR DESCRIPTION
Adds support for Token 2022. 

All accounts in the program should use either 2022 or Token classic, you can't mix and match.

Changes:

- [ ] All ATAs must be derived with `TOKEN_2022_PROGRAM_ID`, e.g.
```
      const reward1TokenAccount = getAssociatedTokenAddressSync(
        rewardMint1,
        program.provider.publicKey,
        undefined,
        TOKEN_2022_PROGRAM_ID
      );
```
- [ ] All instructions must pass `TOKEN_2022_PROGRAM_ID` when `tokenProgram` is an account if using Token2022
- [ ] Governance integration does not work as the governance program currently does not support Token2022, however all 2022 features can be used if no registrar was enabled. If a registrar is enabled, nobody will able to create voter weight records, and thus can deposit but never withdraw.
- [ ] InitializeStakePool unchanged (other than the above)
- [ ] Deposit adds `mint` account (same as stakePool.mint)
- [ ] Withdraw adds `mint` account (same as ClaimBase.stakePool.mint)
- [ ] When using Token2022, Claimbase and Withdraw also requiring passing the Mint in remaining accounts, like:
 ```        
{
          pubkey: rewardVaultKey,
          isWritable: true,
          isSigner: false,
        },
        {
          pubkey: depositorReward1AccountKey,
          isWritable: true,
          isSigner: false,
        },
        {
          pubkey: rewardMint,
          isWritable: false,
          isSigner: false,
        },
/// next set of 3, etc.
```
Classic Token still passes accounts in pairs (rewardVault, DepositorAccount, rewardVault2, DepositorAccount2, etc)